### PR TITLE
Coloring fast paths and improving svg for negative values in X and Y

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,10 @@
 module github.com/256dpi/gcode
 
+go 1.15
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815 h1:bWDMxwH3px2JBh6AyO7hdCn/PkvCZXii8TGj7sbtEbQ=
+github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=

--- a/svg.go
+++ b/svg.go
@@ -61,8 +61,12 @@ func ConvertToSVG(f *File) string {
 	var els []string
 
 	// range over all levels
-	for _, paths := range paths {
-		els = append(els, fmt.Sprintf(`<path d="%s" fill="none" stroke="black" stroke-width="1" />`, strings.Join(paths, " ")))
+	for i, gpath := range paths {
+		stroke := "black"
+		if i == 0 {
+			stroke = "red"
+		}
+		els = append(els, fmt.Sprintf(`<path d="%s" fill="none" stroke="%s" stroke-width="1" />`, strings.Join(gpath, " "), stroke))
 	}
 
 	return fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg">%s</svg>`, strings.Join(els, "\n"))

--- a/svg.go
+++ b/svg.go
@@ -12,6 +12,7 @@ func ConvertToSVG(f *File) string {
 	var x, y float64
 	var g int
 	var path []string
+	var maxX, maxY, shiftX, shiftY float64
 
 	// range over all codes
 	for _, l := range f.Lines {
@@ -43,10 +44,24 @@ func ConvertToSVG(f *File) string {
 				// set state
 				x = c.Value
 				ok = true
+
+				if c.Value > maxX {
+					maxX = c.Value
+				}
+				if c.Value < shiftX {
+					shiftX = c.Value
+				}
 			} else if c.Letter == "Y" {
 				// set state
 				y = c.Value
 				ok = true
+
+				if c.Value > maxY {
+					maxY = c.Value
+				}
+				if c.Value < shiftY {
+					shiftY = c.Value
+				}
 			}
 		}
 
@@ -69,5 +84,5 @@ func ConvertToSVG(f *File) string {
 		els = append(els, fmt.Sprintf(`<path d="%s" fill="none" stroke="%s" stroke-width="1" />`, strings.Join(gpath, " "), stroke))
 	}
 
-	return fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg">%s</svg>`, strings.Join(els, "\n"))
+	return fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="%f %f %f %f">%s</svg>`, shiftX, shiftY, -1*shiftX+maxX, -1*shiftY+maxY, strings.Join(els, "\n"))
 }

--- a/svg_test.go
+++ b/svg_test.go
@@ -21,10 +21,23 @@ func TestConvertToSVG(t *testing.T) {
 					{Letter: "Y", Value: 4},
 				},
 			},
+			{
+				Codes: []GCode{
+					{Letter: "G", Value: 1},
+					{Letter: "X", Value: -1},
+				},
+			},
+			{
+				Codes: []GCode{
+					{Letter: "X", Value: 4},
+					{Letter: "Y", Value: 5},
+				},
+			},
 		},
 	}
 
 	svg := ConvertToSVG(f)
 
-	assert.Equal(t, `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0.000000 0.000000 3.000000 4.000000"><path d=" M0.000000,0.000000 L2.000000,0.000000 L3.000000,4.000000" fill="none" stroke="red" stroke-width="1" /></svg>`, svg)
+	assert.Equal(t, `<svg xmlns="http://www.w3.org/2000/svg" viewBox="-1.000000 0.000000 5.000000 5.000000"><path d=" M0.000000,0.000000 L2.000000,0.000000 L3.000000,4.000000" fill="none" stroke="red" stroke-width="1" />
+<path d="M3.000000,4.000000 L-1.000000,4.000000 L4.000000,5.000000" fill="none" stroke="black" stroke-width="1" /></svg>`, svg)
 }

--- a/svg_test.go
+++ b/svg_test.go
@@ -26,5 +26,5 @@ func TestConvertToSVG(t *testing.T) {
 
 	svg := ConvertToSVG(f)
 
-	assert.Equal(t, `<svg xmlns="http://www.w3.org/2000/svg"><path d=" M0.000000,0.000000 L2.000000,0.000000 L3.000000,4.000000" fill="none" stroke="black" stroke-width="1" /></svg>`, svg)
+	assert.Equal(t, `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0.000000 0.000000 3.000000 4.000000"><path d=" M0.000000,0.000000 L2.000000,0.000000 L3.000000,4.000000" fill="none" stroke="red" stroke-width="1" /></svg>`, svg)
 }


### PR DESCRIPTION
Hey!
I made some improvements to your library regarding the SVG generation. g0 paths are rapid speed paths and IMHO should have a different color to better check for errors in the gcode. It also looks nicer.
Second change is the addition of the viewBox attribute in the svg tag. This allows browsers & co to correctly render the full svg image when there are paths with values lower than zero in the X or Y axis. It also replaces the default width and height of the svg, which is 300x150.

Of course feel free to merge only one of the new features or none of them..

Have a nice day!
Henne